### PR TITLE
Add attributes to operation config

### DIFF
--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
@@ -11,12 +11,6 @@
       "optional": true
     },
     {
-      "name": "operationCreator",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    },
-    {
       "name": "simaVersion",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string"

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
@@ -4,7 +4,6 @@
   "type": "/Blueprints/Config",
   "simaVersion": "1.2.3-rc",
   "operationDescription": "some description",
-  "operationCreator": "ABC",
   "phases": [
     {
       "name": "phase1",


### PR DESCRIPTION
in Configs/ExampleConfig.json, I have to specify "type": "/Blueprints/ConfigForPhase" and "type": "/Blueprints/ConfigForSimulationConfig". It would be better to avoid having to specify this,but im not sure how to do that...

closes #63 