### PR TITLE
Create operation from config

### DIFF
--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
@@ -5,9 +5,21 @@
   "description": "Configuration for operations",
   "attributes": [
     {
+      "name": "operationDescription",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
       "name": "simaVersion",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string"
+    },
+    {
+      "name": "phases",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Phase",
+      "dimensions": "*"
     }
   ],
     "uiRecipes": []

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Config.json
@@ -5,12 +5,6 @@
   "description": "Configuration for operations",
   "attributes": [
     {
-      "name": "operationDescription",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    },
-    {
       "name": "simaVersion",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string"

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Operation.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Operation.json
@@ -5,6 +5,11 @@
   "description": "",
   "attributes": [
     {
+      "name": "label",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
       "name": "stask",
       "attributeType": "/Blueprints/STask",
       "type": "system/SIMOS/BlueprintAttribute"
@@ -15,13 +20,6 @@
       "attributeType": "/Blueprints/Phase",
       "contained": true,
       "dimensions": "*"
-    },
-    {
-      "name" : "config",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "/Blueprints/Config",
-      "optional": true,
-      "contained": false
     },
     {
       "name": "creator",

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Phase.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Blueprints/Phase.json
@@ -34,6 +34,7 @@
       "name": "status",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
+      "default": "Upcoming",
       "optional": true
     },
     {

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
@@ -1,6 +1,43 @@
  {
   "_id": "example-cfg",
   "name": "ExampleConfig",
-  "type": "/Blueprints/Config",
-  "simaVersion": "1.2.3-rc"
-}
+  "type": "ForecastDS/ForecastOfResponse/Blueprints/Config",
+  "simaVersion": "1.2.3-rc",
+  "operationDescription": "some description",
+  "phases": [
+    {
+      "name": "phase1",
+      "type": "ForecastDS/ForecastOfResponse/Blueprints/Phase",
+      "start": "2021-06-25 13:45:37.352574",
+      "end": "2021-06-27 13:45:37.352574",
+      "defaultVariables": [
+        "WaveHeight=0.12",
+        "WaveDirection=30",
+        "Thrusters=2"
+      ],
+      "status": "Ongoing",
+      "activeForecast": {
+        "name": "test1",
+        "type": "ForecastDS/ForecastOfResponse/Blueprints/Simulation",
+        "description": "",
+        "weatherDataId": "25.6,19:15",
+        "progress": "Running",
+        "result": {},
+        "started": "2021-06-27 13:45:37.352574",
+        "ended": "2021-06-27 13:45:37.352574"
+      },
+      "workflowTask": "someTask",
+      "simulationConfigs": [{
+        "name": "test1config",
+        "type": "ForecastDS/ForecastOfResponse/Blueprints/SimulationConfig",
+        "variables": [
+            "WaveHeight=1.12",
+            "WaveHeight=0.6",
+            "WaveDirection=90",
+            "WaveDirection=60"
+          ]
+      }
+        ]
+    }
+  ]
+ }

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfig.json
@@ -3,7 +3,7 @@
   "name": "ExampleConfig",
   "type": "ForecastDS/ForecastOfResponse/Blueprints/Config",
   "simaVersion": "1.2.3-rc",
-  "operationDescription": "some description",
+  "description": "some description",
   "phases": [
     {
       "name": "phase1",

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfigMinimal.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfigMinimal.json
@@ -1,0 +1,18 @@
+ {
+  "name": "ExampleConfigMinimal",
+  "type": "ForecastDS/ForecastOfResponse/Blueprints/Config",
+  "simaVersion": "1.2.3-rc",
+  "operationDescription": "some description",
+  "phases": [
+    {
+      "name": "phase1",
+      "type": "ForecastDS/ForecastOfResponse/Blueprints/Phase",
+      "defaultVariables": [
+        "WaveHeight=1.12",
+        "WaveDirection=90",
+        "Thrusters=5"
+      ],
+      "workflowTask": "someTask"
+    }
+  ]
+ }

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfigMinimal.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Configs/ExampleConfigMinimal.json
@@ -2,7 +2,7 @@
   "name": "ExampleConfigMinimal",
   "type": "ForecastDS/ForecastOfResponse/Blueprints/Config",
   "simaVersion": "1.2.3-rc",
-  "operationDescription": "some description",
+  "description": "some description",
   "phases": [
     {
       "name": "phase1",

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation1.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation1.json
@@ -1,6 +1,7 @@
 {
   "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d4",
   "name": "SverdrupAnchorReplace2021",
+  "label": "Sverdrup Anchor Replace 2021",
   "type": "/Blueprints/Operation",
   "description": "Bridge forecast",
   "stask": {

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation2.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation2.json
@@ -1,6 +1,7 @@
 {
   "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d2",
   "name": "MoveWindRig2020",
+  "label": "Move wind rig 2020",
   "type": "/Blueprints/Operation",
   "description": "an example operation",
   "stask": {

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation3.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation3.json
@@ -1,6 +1,7 @@
 {
   "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d3",
   "name": "ChangeMotor2021",
+  "label": "Change motor 2021",
   "type": "/Blueprints/Operation",
   "description": "an example operation",
   "stask": {

--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation4.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation4.json
@@ -1,6 +1,7 @@
 {
   "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d5",
   "name": "TestMotor",
+  "label": "test motor",
   "type": "/Blueprints/Operation",
   "description": "an example operation",
   "stask": {

--- a/web/custom-plugins/forecast-of-response/src/Pages/Dashboard.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/Dashboard.tsx
@@ -63,7 +63,7 @@ const Dashboard = (): JSX.Element => {
               return [
                 location.lat,
                 location.long,
-                operation.name,
+                operation.label,
                 operation._id,
               ]
             })

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
@@ -139,7 +139,7 @@ const createOperationEntity = (
     {
       name: operationName,
       label: operationLabel,
-      description: config.operationDescription,
+      description: config.description,
       type: Blueprints.OPERATION,
       stask: {
         type: Blueprints.STASK,
@@ -228,7 +228,7 @@ const onClickCreate = (
 
 const OperationCreate = (): JSX.Element => {
   const { userData, token } = useContext(AuthContext)
-  const user = userData.loggedIn ? userData.username : 'Anonymous'
+  const user = userData.username
   const [error, setError] = useState<string>()
   const [operationMeta, setOperationMeta] = useState<TOperationMeta>({
     name: '',
@@ -252,14 +252,14 @@ const OperationCreate = (): JSX.Element => {
   // TODO: Add "Save as Draft" button?
 
   const storeAndCheckOperationConfig = (
-    newOperationConfig: any,
+    newOperationConfig: TConfig,
     filename: string
   ) => {
     //todo the type checking can be improved... required attributes is defined in the type TConfig.
     const hasRequiredAttirbutes =
-      newOperationConfig.name &&
-      newOperationConfig.simaVersion &&
-      newOperationConfig.phases
+      'name' in newOperationConfig &&
+      'simaVersion' in newOperationConfig &&
+      'phases' in newOperationConfig
     if (hasRequiredAttirbutes) {
       setOperationConfig(newOperationConfig)
     } else {
@@ -276,11 +276,19 @@ const OperationCreate = (): JSX.Element => {
         <InputGroupWrapper>
           <SelectOperationName
             setOperationName={(operationName: string) => {
-              setOperationMeta({
-                ...operationMeta,
-                label: operationName,
-                name: operationName.replace(' ', '-'),
-              })
+              const format = new RegExp('^[A-Za-z0-9-_ ]+$')
+              if (!format.test(operationName)) {
+                setError(
+                  'Invalid operation name! (you cannot use any special characters).'
+                )
+              } else {
+                setError('')
+                setOperationMeta({
+                  ...operationMeta,
+                  label: operationName,
+                  name: operationName.replace(' ', '-'),
+                })
+              }
             }}
           />
           <Wrapper>
@@ -328,23 +336,25 @@ const OperationCreate = (): JSX.Element => {
       >
         <Button
           onClick={() => {
-            if (operationLocation && operationConfig && sTask) {
-              onClickCreate(
-                operationMeta,
-                operationLocation,
-                operationConfig,
-                sTask,
-                isNewEntity,
-                setError,
-                token,
-                user
-              )
-            } else {
-              setError('All required information is not set!')
-            }
+            onClickCreate(
+              operationMeta,
+              operationLocation,
+              operationConfig,
+              sTask,
+              isNewEntity,
+              setError,
+              token,
+              user
+            )
           }}
           disabled={
-            !(sTask && operationLocation && operationMeta && operationConfig)
+            !(
+              sTask &&
+              operationLocation &&
+              operationMeta &&
+              operationConfig &&
+              !error
+            )
           }
         >
           Create operation

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
@@ -6,7 +6,7 @@ import { addToPath } from '../utils/insertDocument'
 import { DEFAULT_DATASOURCE_ID } from '../const'
 import DateRangePicker from '../components/DateRangePicker'
 import { Heading } from '../components/Design/Fonts'
-import { TConfig, TLocation } from '../Types'
+import { TConfig, TLocation, TOperationMeta, TPhase } from '../Types'
 import SelectOperationConfig from '../components/Operations/SelectConfig'
 import SelectOperationLocation from '../components/Operations/SelectLocation'
 import { ClickableMap } from '../components/Map'
@@ -79,6 +79,35 @@ const getEntityId = (
   isNew: boolean = false
 ): PromiseLike<string> => {
   if (isNew) {
+    //A function for automatically setting the correct types in a config entity - can be used if we decide to not require types in uploaded config files.
+    //NB! relative paths ("/Blueprints/Config") does not work when uploading a new config.
+
+    // export const CONFIG_BLUEPRINT =
+    //   'ForecastDS/ForecastOfResponse/Blueprints/Config'
+    // export const PHASE_BLUEPRINT = 'ForecastDS/ForecastOfResponse/Blueprints/Phase'
+    // export const SIMULATION_BLUEPRINT =
+    //   'ForecastDS/ForecastOfResponse/Blueprints/Simulation'
+    // export const SIMULATION_CONFIG_BLUEPRINT =
+    //   'ForecastDS/ForecastOfResponse/Blueprints/SimulationConfig'
+
+    // const entityIsConfig = (entity as TConfig).type
+    // if (entityIsConfig) {
+    //   //add types to the config entity
+    //   entity['type'] = CONFIG_BLUEPRINT
+    //   //@ts-ignore - safe type ignore here since the if statement checks the entity type
+    //   if (entity?.phases) {
+    //     entity.phases.map((phase: TPhase) => {
+    //       phase['type'] = PHASE_BLUEPRINT
+    //       if (phase.activeForecast)
+    //         phase.activeForecast['type'] = SIMULATION_BLUEPRINT
+    //       if (phase.simulationConfigs) {
+    //         phase.simulationConfigs.map((simConfig) => {
+    //           simConfig['type'] = SIMULATION_CONFIG_BLUEPRINT
+    //         })
+    //       }
+    //     })
+    //   }
+    // }
     return addToPath(entity, token)
   } else {
     return new Promise((resolve: any) => {
@@ -98,6 +127,7 @@ const getEntityId = (
  */
 const createOperationEntity = (
   operationName: string,
+  operationLabel: string,
   stask: File,
   dateRange: Date[],
   location: TLocation,
@@ -108,6 +138,8 @@ const createOperationEntity = (
   return addToPath(
     {
       name: operationName,
+      label: operationLabel,
+      description: config.operationDescription,
       type: Blueprints.OPERATION,
       stask: {
         type: Blueprints.STASK,
@@ -122,7 +154,7 @@ const createOperationEntity = (
       start: dateRange && dateRange[0] ? dateRange[0].toISOString() : undefined,
       end: dateRange && dateRange[1] ? dateRange[1].toISOString() : undefined,
       status: OperationStatus.UPCOMING, // TODO: decide based on start attr? allow user to select?
-      config: config,
+      phases: config.phases,
     },
     token,
     [stask]
@@ -130,10 +162,10 @@ const createOperationEntity = (
 }
 
 const onClickCreate = (
-  operationMeta: { name: string; dateRange: Date[] },
+  operationMeta: TOperationMeta,
   operationLocation: TLocation,
   operationConfig: TConfig,
-  stask: Blob,
+  stask: File,
   isNewEntity: { location: boolean; config: boolean },
   setError: Function,
   token: string,
@@ -155,6 +187,7 @@ const onClickCreate = (
       if (isNewEntity.config) operationConfig._id = documentIds[1]
       createOperationEntity(
         operationMeta.name,
+        operationMeta.label,
         stask,
         operationMeta.dateRange,
         operationLocation,
@@ -163,12 +196,11 @@ const onClickCreate = (
         user
       )
         .then((documentId) => {
-          // todo redirect to operation view
-          console.log(`New operation ${documentId}`)
           const newLocation = document.location.pathname.replace(
             'new',
             `${DEFAULT_DATASOURCE_ID}/${documentId}`
           )
+          // @ts-ignore
           document.location = newLocation
         })
         .catch((err: any) => {
@@ -196,25 +228,46 @@ const onClickCreate = (
 
 const OperationCreate = (): JSX.Element => {
   const { userData, token } = useContext(AuthContext)
-  const user = userData.loggedIn ? userData.name : 'Anonymous'
+  const user = userData.loggedIn ? userData.username : 'Anonymous'
   const [error, setError] = useState<string>()
-  const [operationMeta, setOperationMeta] = useState<{
-    name: string
-    dateRange: Date[]
-  }>()
+  const [operationMeta, setOperationMeta] = useState<TOperationMeta>({
+    name: '',
+    label: '',
+    dateRange: [],
+  })
+
   const [isNewEntity, setIsNewEntity] = useState<{
     location: boolean
     config: boolean
   }>({ location: false, config: false })
   const [operationConfig, setOperationConfig] = useState<TConfig>()
-  const [sTask, setSTask] = useState<Blob>()
-  const [operationLocation, setOperationLocation] = useState<TLocation>({})
+  const [sTask, setSTask] = useState<File>()
+  const [operationLocation, setOperationLocation] = useState<
+    TLocation | undefined
+  >()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [mapClickPos, setMapClickPos] = useState<[number, number]>()
+  const [mapClickPos, setMapClickPos] = useState<[number, number] | undefined>()
 
-  // TODO: redirect to operation view upon creation
   // TODO: Upon clicking cancel, ask for confirmation and whether it should be saved as a draft
   // TODO: Add "Save as Draft" button?
+
+  const storeAndCheckOperationConfig = (
+    newOperationConfig: any,
+    filename: string
+  ) => {
+    //todo the type checking can be improved... required attributes is defined in the type TConfig.
+    const hasRequiredAttirbutes =
+      newOperationConfig.name &&
+      newOperationConfig.simaVersion &&
+      newOperationConfig.phases
+    if (hasRequiredAttirbutes) {
+      setOperationConfig(newOperationConfig)
+    } else {
+      setError(
+        `Could not parse content of the configuration file ${filename}. Do the file have all required attributes?`
+      )
+    }
+  }
 
   return (
     <>
@@ -223,7 +276,11 @@ const OperationCreate = (): JSX.Element => {
         <InputGroupWrapper>
           <SelectOperationName
             setOperationName={(operationName: string) => {
-              setOperationMeta({ ...operationMeta, name: operationName })
+              setOperationMeta({
+                ...operationMeta,
+                label: operationName,
+                name: operationName.replace(' ', '-'),
+              })
             }}
           />
           <Wrapper>
@@ -235,15 +292,15 @@ const OperationCreate = (): JSX.Element => {
             />
           </Wrapper>
           <SelectOperationConfig
-            setOperationConfig={setOperationConfig}
+            setOperationConfig={storeAndCheckOperationConfig}
             setIsNewConfig={(isNew: boolean) => {
               setIsNewEntity({ ...isNewEntity, config: isNew })
             }}
             isLoading={isLoading}
+            setError={setError}
             setIsLoading={setIsLoading}
           />
           <SelectSTask setSTask={setSTask} isLoading={isLoading} />
-
           <SelectOperationLocation
             location={operationLocation}
             setLocation={setOperationLocation}
@@ -270,18 +327,22 @@ const OperationCreate = (): JSX.Element => {
         }}
       >
         <Button
-          onClick={() =>
-            onClickCreate(
-              operationMeta,
-              operationLocation,
-              operationConfig,
-              sTask,
-              isNewEntity,
-              setError,
-              token,
-              user
-            )
-          }
+          onClick={() => {
+            if (operationLocation && operationConfig && sTask) {
+              onClickCreate(
+                operationMeta,
+                operationLocation,
+                operationConfig,
+                sTask,
+                isNewEntity,
+                setError,
+                token,
+                user
+              )
+            } else {
+              setError('All required information is not set!')
+            }
+          }}
           disabled={
             !(sTask && operationLocation && operationMeta && operationConfig)
           }

--- a/web/custom-plugins/forecast-of-response/src/Types.ts
+++ b/web/custom-plugins/forecast-of-response/src/Types.ts
@@ -34,9 +34,13 @@ export type TLocation = {
   type?: string
 }
 
+export type TOperationMeta = { name: string; label: string; dateRange: Date[] }
+
 export type TConfig = {
   name: string
   simaVersion: string
+  phases: TPhase[]
+  operationDescription?: string
   _id?: string
   type?: string
 }
@@ -65,6 +69,7 @@ export type TPhase = {
   name: string
   start?: Date
   end?: Date
+  activeForecast?: TSimulation
   status?: OperationStatus
   defaultVariables?: StringMap
 }
@@ -83,6 +88,7 @@ export type TOperation = {
   _id?: string
   type?: string
   name: string
+  label: string
   stask: TStask
   description?: string
   creator: string
@@ -91,7 +97,6 @@ export type TOperation = {
   status?: OperationStatus
   location: TLocation
   phases: TPhase[]
-  config?: TConfig
   comments?: TComment
 }
 

--- a/web/custom-plugins/forecast-of-response/src/Types.ts
+++ b/web/custom-plugins/forecast-of-response/src/Types.ts
@@ -40,7 +40,7 @@ export type TConfig = {
   name: string
   simaVersion: string
   phases: TPhase[]
-  operationDescription?: string
+  description?: string
   _id?: string
   type?: string
 }

--- a/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
@@ -111,8 +111,11 @@ const InputWrapper = styled.div`
   flex-direction: column;
   margin: 15px;
 `
-export const CommentInput = (props: { operationId: string }) => {
-  const { operationId } = props
+export const CommentInput = (props: {
+  operationId: string
+  handleNewComment: any
+}) => {
+  const { operationId, handleNewComment } = props
   const [message, setMessage] = useState<string>('')
   const { token, userData } = useContext(AuthContext)
   const dmssAPI = new DmssAPI(token)
@@ -120,19 +123,23 @@ export const CommentInput = (props: { operationId: string }) => {
   function handlePost() {
     // TODO: When we can import model contained data, remove name from Comment
     const commentName = crypto.randomUUID()
+    const newComment = {
+      name: commentName,
+      type: Blueprints.Comment,
+      author: userData?.username || 'anon',
+      date: new Date().toISOString(),
+      message: message,
+    }
     dmssAPI.generatedDmssApi
       .explorerAdd({
         dataSourceId: DEFAULT_DATASOURCE_ID,
         dottedId: `${operationId}.comments`,
-        body: {
-          name: commentName,
-          type: Blueprints.Comment,
-          author: userData?.name || 'Anonymous',
-          date: new Date().toISOString(),
-          message: message,
-        },
+        body: newComment,
       })
-      .then(() => setMessage(''))
+      .then(() => {
+        handleNewComment(newComment)
+        setMessage('')
+      })
   }
 
   return (
@@ -150,7 +157,9 @@ export const CommentInput = (props: { operationId: string }) => {
           }
         />
         <div style={{ justifyContent: 'space-around', display: 'flex' }}>
-          <Button color="danger">Cancel</Button>
+          <Button color="danger" onClick={() => setMessage('')}>
+            Cancel
+          </Button>
           <Button disabled={message === ''} onClick={() => handlePost()}>
             Comment
           </Button>

--- a/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
@@ -126,7 +126,7 @@ export const CommentInput = (props: {
     const newComment = {
       name: commentName,
       type: Blueprints.Comment,
-      author: userData?.username || 'anon',
+      author: userData.username,
       date: new Date().toISOString(),
       message: message,
     }

--- a/web/custom-plugins/forecast-of-response/src/components/Map.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Map.tsx
@@ -36,7 +36,7 @@ interface ILocationOnMap {
 }
 
 interface IClickableMap {
-  location: TLocation
+  location: TLocation | undefined
   zoom: number
   setClickPos: Function
 }
@@ -70,7 +70,7 @@ export const ClickableMap = ({
   zoom,
   setClickPos,
 }: IClickableMap): JSX.Element => {
-  const marker = [location.lat || 60, location.long || 4]
+  const marker = [location?.lat || 60, location?.long || 4]
   const [clickLocation, setClickLocation] = useState<[number, number]>()
 
   return (

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
@@ -40,9 +40,7 @@ export default (props: { operation: TOperation }): JSX.Element => {
   const [comments, setComments] = useState<TComment[]>(operation.comments)
 
   const updateComments = (newComment: TComment) => {
-    let newCommentList: TComment[] = comments.slice()
-    newCommentList.push(newComment)
-    setComments(newCommentList)
+    setComments([...comments, newComment])
   }
 
   return (

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
@@ -37,11 +37,21 @@ const CommentsWrapper = styled.div`
 export default (props: { operation: TOperation }): JSX.Element => {
   const { operation } = props
   const [viewACL, setViewACL] = useState<boolean>(false)
+  const [comments, setComments] = useState<TComment[]>(operation.comments)
+
+  const updateComments = (newComment: TComment) => {
+    let newCommentList: TComment[] = comments.slice()
+    newCommentList.push(newComment)
+    setComments(newCommentList)
+  }
+
   return (
     <Card style={{ border: 'solid 1px', maxWidth: '1200px' }}>
       <Card.Header>
         <Card.HeaderTitle>
-          <Typography variant="h5">{operation.name}</Typography>
+          <Typography variant="h5">
+            {operation.label || operation.name}
+          </Typography>
           <Typography variant="body_short">
             {operation.location.name}
           </Typography>
@@ -80,8 +90,8 @@ export default (props: { operation: TOperation }): JSX.Element => {
         </LocationWrapper>
       </div>
       <Card.Actions>
-        <Button>Cancel</Button>
-        <Button>OK</Button>
+        <Button disabled={true}>Cancel</Button>
+        <Button disabled={true}>OK</Button>
       </Card.Actions>
       <Card.Actions>
         <Button
@@ -96,7 +106,7 @@ export default (props: { operation: TOperation }): JSX.Element => {
         <AccessControlList
           documentId={operation._id}
           dataSourceId={DEFAULT_DATASOURCE_ID}
-        ></AccessControlList>
+        />
       )}
       <Table density="comfortable" style={{ width: '100%' }}>
         <Table.Caption>
@@ -137,7 +147,7 @@ export default (props: { operation: TOperation }): JSX.Element => {
       </Table>
       <h4>Comments</h4>
       <CommentsWrapper>
-        {operation.comments.map((comment: TComment, index: number) => (
+        {comments.map((comment: TComment, index: number) => (
           <CommentView
             key={comment._id}
             comment={comment}
@@ -145,7 +155,10 @@ export default (props: { operation: TOperation }): JSX.Element => {
           />
         ))}
       </CommentsWrapper>
-      <CommentInput operationId={operation._id} />
+      <CommentInput
+        operationId={operation._id}
+        handleNewComment={updateComments}
+      />
     </Card>
   )
 }

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationsTable.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationsTable.tsx
@@ -46,7 +46,7 @@ const OperationsTable = (props: {
 
     let row: TOperationRow = {
       _id: operation._id,
-      name: operation.name,
+      name: operation.label || operation.name,
       start: startDate,
       end: endDate,
       location: operation.location.name,

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/SelectConfig.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/SelectConfig.tsx
@@ -38,6 +38,7 @@ const SelectOperationConfig = (props: {
   setIsNewConfig: Function
   isLoading: boolean
   setIsLoading: Function
+  setError: Function
 }): JSX.Element => {
   const [operationConfigs, setOperationConfigs] = useState<TConfig[]>([])
   const [searchResult, isLoadingSearch, hasError] = useSearch(
@@ -45,7 +46,17 @@ const SelectOperationConfig = (props: {
   )
   const [fileName, setFileName] = useState<string>()
   const [uploadNew, setUploadNew] = useState<boolean>(true)
-  const { setOperationConfig, setIsNewConfig, isLoading, setIsLoading } = props
+  const [
+    configEntitiesInDatabase,
+    configEntitiesLoading,
+  ]: TConfig[] = useSearch('ForecastDS/ForecastOfResponse/Blueprints/Config')
+  const {
+    setOperationConfig,
+    setIsNewConfig,
+    isLoading,
+    setIsLoading,
+    setError,
+  } = props
 
   /**
    * Set operation configs when the search has completed
@@ -55,6 +66,23 @@ const SelectOperationConfig = (props: {
       setOperationConfigs(searchResult)
     }
   }, [searchResult])
+
+  const isDuplicateConfigName = (
+    configName: string,
+    configEntitiesInDatabase: TConfig[]
+  ) => {
+    if (configEntitiesInDatabase) {
+      configEntitiesInDatabase.map((configEntity: any) => {
+        if (configEntity.name === configName) {
+          setError(
+            'A config with the same name attribute already exists! Try to change the attribute "name" inside the json file.'
+          )
+          return false
+        }
+      })
+    }
+    return true
+  }
 
   return (
     <Wrapper>
@@ -82,6 +110,7 @@ const SelectOperationConfig = (props: {
               style={{ display: 'none' }}
               accept=".json"
               onChange={(event: any) => {
+                setError('')
                 if (event.target.files.length >= 1) {
                   const file = event.target.files[0]
                   if (file.type === 'application/json') {
@@ -90,17 +119,24 @@ const SelectOperationConfig = (props: {
                     readFile(file)
                       .then((contents: string) => {
                         const configJson = JSON.parse(contents)
+                        isDuplicateConfigName(
+                          configJson['name'],
+                          configEntitiesInDatabase
+                        )
                         setIsNewConfig(true)
-                        setOperationConfig(configJson)
+                        setOperationConfig(configJson, file.name)
                         setIsLoading(false)
                       })
                       .catch((err: any) => {
                         console.error(err)
+                        setError(
+                          `Could not read the content of ${file.name}! Content was not in correct json format.`
+                        )
                         setIsLoading(false)
                       })
                   } else {
-                    console.error(
-                      'Specified file is not in the required format (JSON).'
+                    setError(
+                      'Selected configuration file is not in the required format (JSON).'
                     )
                   }
                 }

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/SelectConfig.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/SelectConfig.tsx
@@ -67,23 +67,6 @@ const SelectOperationConfig = (props: {
     }
   }, [searchResult])
 
-  const isDuplicateConfigName = (
-    configName: string,
-    configEntitiesInDatabase: TConfig[]
-  ) => {
-    if (configEntitiesInDatabase) {
-      configEntitiesInDatabase.map((configEntity: any) => {
-        if (configEntity.name === configName) {
-          setError(
-            'A config with the same name attribute already exists! Try to change the attribute "name" inside the json file.'
-          )
-          return false
-        }
-      })
-    }
-    return true
-  }
-
   return (
     <Wrapper>
       <Heading text="Configuration file" variant="h4" />
@@ -119,19 +102,16 @@ const SelectOperationConfig = (props: {
                     readFile(file)
                       .then((contents: string) => {
                         const configJson = JSON.parse(contents)
-                        isDuplicateConfigName(
-                          configJson['name'],
-                          configEntitiesInDatabase
-                        )
                         setIsNewConfig(true)
                         setOperationConfig(configJson, file.name)
-                        setIsLoading(false)
                       })
                       .catch((err: any) => {
                         console.error(err)
                         setError(
                           `Could not read the content of ${file.name}! Content was not in correct json format.`
                         )
+                      })
+                      .finally(() => {
                         setIsLoading(false)
                       })
                   } else {

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/SelectLocation.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/SelectLocation.tsx
@@ -61,10 +61,10 @@ const SelectLocation = (props: {
 }
 
 const SelectOperationLocation = (props: {
-  location: TLocation
+  location: TLocation | undefined
   setLocation: Function
   setIsNewLocation: Function
-  mapClickPos: [number, number]
+  mapClickPos: [number, number] | undefined
 }): JSX.Element => {
   const [selectLocationType, setSelectLocationType] = useState<string>('select')
   const { location, setLocation, setIsNewLocation, mapClickPos } = props
@@ -86,6 +86,7 @@ const SelectOperationLocation = (props: {
           New
         </Button>
       </LocationButtonsGrid>
+
       {selectLocationType === 'select' ? (
         <SelectLocation
           setLocation={setLocation}
@@ -108,15 +109,18 @@ const SelectOperationLocation = (props: {
             onChange={(event: any) =>
               setLocation({ ...location, lat: event.target.value })
             }
-            value={location.lat || ''}
+            value={location?.lat || ''}
           />
           <TextField
             id="long-input"
             label="Longitude"
             onChange={(event: any) => {
-              setLocation({ ...location, long: parseFloat(event.target.value) })
+              setLocation({
+                ...location,
+                long: parseFloat(event.target.value),
+              })
             }}
-            value={location.long || ''}
+            value={location?.long || ''}
           />
           <div style={{ width: '150px', marginTop: '10px' }}>
             <Button


### PR DESCRIPTION
* fix comment bug: the  comment component did not update when a new comment was added
* display the operation label (which allows spaces) instead of the name
* disable some unused buttons
* functionality for creating operation from config
* error checking when uploading a config file (can be improved...)
closes #61 
closes #63 