### PR TITLE
trigger sre jobs from Forecast of Response. View logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 data/*
 node_modules
+/sima.lic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,10 @@ services:
       LOGGING_LEVEL: DEBUG
       ENVIRONMENT: local
       DMSS_API: http://dmss:5000
+      # Used for callback from Azure Container Job
+      PUBLIC_DMSS_API: https://dmss-forecast-of-response-test.radix.equinor.com
 #      SCHEDULER_REDIS_PASSWORD: ${SCHEDULER_REDIS_PASSWORD}
+      SCHEDULER_ENVS_TO_EXPORT: "PUBLIC_DMSS_API,SIMA_LICENSE"
       SCHEDULER_REDIS_HOST: job-store
       SCHEDULER_REDIS_PORT: 6379
       SCHEDULER_REDIS_SSL: "false"
@@ -22,6 +25,8 @@ services:
       AZURE_SP_SECRET: ${AZURE_SP_SECRET}
       AZURE_JOB_SP_TENANT_ID: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
       AZURE_JOB_SP_CLIENT_ID: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
+#      SIMA_LICENSE: |
+# $(cat ./sima.lic)
     volumes:
       - ./api/home/:/code/home
 

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -21,6 +21,7 @@ spec:
       secrets:
         - AZURE_SP_SECRET
         - SCHEDULER_REDIS_PASSWORD
+        - SIMA_LICENSE
       environmentConfig:
         - environment: test
           variables:
@@ -32,7 +33,9 @@ spec:
             AZURE_JOB_SP_TENANT_ID: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
             AZURE_JOB_SP_CLIENT_ID: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
             DMSS_API: http://dmss:5000
+            PUBLIC_DMSS_API: https://dmss-forecast-of-response-test.radix.equinor.com
             ENVIRONMENT: production
+            SCHEDULER_ENVS_TO_EXPORT: "PUBLIC_DMSS_API,SIMA_LICENSE"
       ports:
         - name: flask
           port: 5000

--- a/web/custom-plugins/forecast-of-response/src/Types.ts
+++ b/web/custom-plugins/forecast-of-response/src/Types.ts
@@ -75,7 +75,7 @@ export type TPhase = {
 }
 
 export type TBlob = {
-  _id: string
+  _blob_id: string
   name: string
   type: string
 }

--- a/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
@@ -7,6 +7,7 @@ import { DmssAPI, AuthContext } from '@dmt/common'
 import { DEFAULT_DATASOURCE_ID } from '../const'
 import { Blueprints } from '../Enums'
 import { IconWrapper } from './Other'
+import { poorMansUUID } from '../utils/uuid'
 
 const CommentHeaderWrapper = styled.div`
   display: flex;
@@ -108,10 +109,9 @@ export const CommentInput = (props: {
   const dmssAPI = new DmssAPI(token)
 
   function handlePost() {
-    // TODO: When we can import model contained data, remove name from Comment
-    const commentName = crypto.randomUUID()
+    // TODO: When we can import model contained data, remove 'name' attribute from Comment
     const newComment = {
-      name: commentName,
+      name: poorMansUUID(),
       type: Blueprints.Comment,
       author: userData.username,
       date: new Date().toISOString(),

--- a/web/custom-plugins/forecast-of-response/src/components/Jobs.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Jobs.tsx
@@ -1,0 +1,71 @@
+import React, { useContext, useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { AuthContext } from '@dmt/common'
+import JobApi from '../utils/JobApi'
+import { SimulationStatus } from '../Enums'
+
+const StyledPre = styled.pre`
+  display: flex;
+  white-space: pre-line;
+`
+
+function colorFromStatus(status: string): string {
+  switch (status) {
+    case SimulationStatus.COMPLETED:
+      return 'green'
+    case SimulationStatus.FAILED:
+      return 'red'
+    case SimulationStatus.RUNNING:
+      return 'orange'
+    default:
+      return 'darkgrey'
+  }
+}
+
+const SimStatusWrapper = styled.div`
+  display: flex;
+  border-radius: 8px;
+  padding: 0 3px;
+  margin-left: 10px;
+  border: ${(props: any) => `${colorFromStatus(props.status)} 3px solid`};
+  color: ${(props: any) => colorFromStatus(props.status)};
+  font-weight: bolder;
+`
+
+export const JobLog = (props: { jobId: string }) => {
+  const { jobId } = props
+  const { token } = useContext(AuthContext)
+  const jobAPI = new JobApi(token)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [jobLogs, setJobLogs] = useState<any>()
+  const [jobStatus, setJobStatus] = useState<any>()
+
+  useEffect(() => {
+    setLoading(true)
+    jobAPI
+      .statusJob(jobId)
+      .then((result: any) => {
+        setJobLogs(result.data.log)
+        setJobStatus(result.data.status)
+      })
+      .catch((e: Error) => {
+        setJobLogs(e.response.data.message)
+        setJobStatus(SimulationStatus.FAILED)
+        console.error(e)
+      })
+      .finally(() => setLoading(false))
+  }, [jobId])
+
+  if (loading) return <pre>Loading...</pre>
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <label>Status: </label>
+        <SimStatusWrapper status={jobStatus}>{jobStatus}</SimStatusWrapper>
+      </div>
+      <label>Logs:</label>
+      <StyledPre>{jobLogs}</StyledPre>
+    </div>
+  )
+}

--- a/web/custom-plugins/forecast-of-response/src/utils/uuid.js
+++ b/web/custom-plugins/forecast-of-response/src/utils/uuid.js
@@ -1,0 +1,5 @@
+export function poorMansUUID() {
+  const randomNumbers = new Uint8Array(10)
+  window.crypto.getRandomValues(randomNumbers)
+  return randomNumbers.reduce((a, b) => a.toString() + b.toString())
+}


### PR DESCRIPTION
- Trigger SIMA job from Forecast of response (public sreWrapper image)
- Adds a comma separated variable to define which env variables to forward to jobs
- Adds a callback URL variable for jobs
- Adds the SIMA_LICENSE secret to radix
- Display logs of simulation jobs without results 