### PR TITLE
enable publish sim functionality. Separate operator phase view

### DIFF
--- a/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation1.json
+++ b/api/home/for/data/ForecastDS/ForecastOfResponse/Operations/operation1.json
@@ -72,6 +72,7 @@
       "simulationConfigs": [
         {
           "name": "test1",
+          "published": true,
           "type": "/Blueprints/SimulationConfig",
           "simulations": [
             {

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationOverview.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationOverview.tsx
@@ -11,6 +11,7 @@ import DateRangePicker from '../components/DateRangePicker'
 import Grid from '../components/App/Grid'
 import { OperationStatus } from '../Enums'
 import { DEFAULT_DATASOURCE_ID, DEFAULT_DIRECTORY } from '../const'
+import { hasExpertRole } from '../utils/auth'
 
 const GridContainer = styled.div`
   padding-top: 50px;
@@ -174,7 +175,9 @@ const OperationOverview = (props: DmtSettings): JSX.Element => {
                   state: location.state,
                 }}
               >
-                <Button>Create new operation</Button>
+                {hasExpertRole(userData) && (
+                  <Button>Create new operation</Button>
+                )}
               </Link>
             </div>
           </Grid>

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationView.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { useDocument } from '@dmt/common'
+import { useDocument, AuthContext } from '@dmt/common'
 import { Tabs } from '@equinor/eds-core-react'
 import { TOperation, TPhase } from '../Types'
 import OperationDetails from '../components/Operations/OperationDetails'
 import PhaseView from '../components/Operations/PhaseView'
+import { hasExpertRole } from '../utils/auth'
+import OperatorPhaseView from '../components/Operations/OperatorPhaseView'
 
 export default (): JSX.Element => {
   const { data_source, entity_id } = useParams()
@@ -14,6 +16,7 @@ export default (): JSX.Element => {
   )
   const [activeTab, setActiveTab] = useState<number>(0)
   const [phases, setPhases] = useState<TPhase[]>([])
+  const { userData } = useContext(AuthContext)
   const operation: TOperation = document
 
   useEffect(() => {
@@ -48,11 +51,15 @@ export default (): JSX.Element => {
           {phases.length ? (
             phases.map((phase: TPhase, index: number) => (
               <Tabs.Panel key={phase.name}>
-                <PhaseView
-                  phase={phase}
-                  dottedId={`${operation._id}.phases.${index}`}
-                  stask={operation.stask}
-                />
+                {hasExpertRole(userData) ? (
+                  <PhaseView
+                    phase={phase}
+                    dottedId={`${operation._id}.phases.${index}`}
+                    stask={operation.stask}
+                  />
+                ) : (
+                  <OperatorPhaseView phase={phase} />
+                )}
               </Tabs.Panel>
             ))
           ) : (

--- a/web/custom-plugins/forecast-of-response/src/components/App/Header.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/App/Header.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
-import { TopBar } from '@equinor/eds-core-react'
+import React, { useContext, useState } from 'react'
+import { Button, Scrim, TopBar } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 import Icon from '../Design/Icons'
+import { AuthContext } from '@dmt/common'
 
 const Icons = styled.div`
   display: flex;
@@ -12,8 +13,17 @@ const Icons = styled.div`
   }
 `
 
+const ClickableIcon = styled.div`
+  &:hover {
+    color: gray;
+    cursor: pointer;
+  }
+`
+
 export default (props: { appName: string }): JSX.Element => {
   const { appName } = props
+  const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
+  const { userData } = useContext(AuthContext)
   return (
     <TopBar>
       <TopBar.Header>
@@ -22,10 +32,28 @@ export default (props: { appName: string }): JSX.Element => {
       </TopBar.Header>
       <TopBar.Actions>
         <Icons>
-          <Icon name="account_circle" size={24} title="user" />
+          <ClickableIcon onClick={() => setVisibleUserInfo(true)}>
+            <Icon name="account_circle" size={24} title="user" />
+          </ClickableIcon>
           <Icon name="notifications" size={24} title="notifications" />
         </Icons>
       </TopBar.Actions>
+      {visibleUserInfo && (
+        <Scrim onClose={() => setVisibleUserInfo(false)} isDismissable>
+          <div
+            style={{
+              backgroundColor: '#fff',
+              padding: '1rem',
+              maxWidth: '600px',
+            }}
+          >
+            <pre style={{ whiteSpace: 'pre-line' }}>
+              {JSON.stringify(userData || '', null, 2)}
+            </pre>
+            <Button onClick={() => setVisibleUserInfo(false)}>Close</Button>
+          </div>
+        </Scrim>
+      )}
     </TopBar>
   )
 }

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { TOperation } from '../Types'
 import { Button, Card, Label, Table, Typography } from '@equinor/eds-core-react'
 import { StatusDot } from '../Other'
@@ -6,8 +6,9 @@ import styled from 'styled-components'
 import { LocationOnMap } from '../Map'
 import { TComment, TPhase } from '../../Types'
 import { CommentInput, CommentView } from '../Comments'
-import { AccessControlList } from '@dmt/common'
+import { AccessControlList, AuthContext } from '@dmt/common'
 import { DEFAULT_DATASOURCE_ID } from '../../const'
+import { hasExpertRole } from '../../utils/auth'
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -38,6 +39,7 @@ export default (props: { operation: TOperation }): JSX.Element => {
   const { operation } = props
   const [viewACL, setViewACL] = useState<boolean>(false)
   const [comments, setComments] = useState<TComment[]>(operation.comments)
+  const { userData } = useContext(AuthContext)
 
   const updateComments = (newComment: TComment) => {
     setComments([...comments, newComment])
@@ -88,17 +90,15 @@ export default (props: { operation: TOperation }): JSX.Element => {
         </LocationWrapper>
       </div>
       <Card.Actions>
-        <Button disabled={true}>Cancel</Button>
-        <Button disabled={true}>OK</Button>
-      </Card.Actions>
-      <Card.Actions>
-        <Button
-          onClick={() => {
-            setViewACL(!viewACL)
-          }}
-        >
-          {viewACL ? 'Hide access panel' : 'Open access panel'}
-        </Button>
+        {hasExpertRole(userData) && (
+          <Button
+            onClick={() => {
+              setViewACL(!viewACL)
+            }}
+          >
+            {viewACL ? 'Hide access panel' : 'Open access panel'}
+          </Button>
+        )}
       </Card.Actions>
       {viewACL && (
         <AccessControlList

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperatorPhaseView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperatorPhaseView.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react'
+import { TPhase, TSimulation, TSimulationConfig } from '../../Types'
+import { StyledSelect } from '../Input'
+import Result from '../Result'
+
+export default (props: { phase: TPhase }): JSX.Element => {
+  const { phase } = props
+  const publishedSimulation = phase.simulationConfigs.find(
+    (simConf: TSimulationConfig) => simConf?.published === true
+  )
+  const [selectedSim, setSelectedSim] = useState<number>(0)
+
+  if (!publishedSimulation)
+    return <div>No results have been published for this operation phase</div>
+
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', position: 'relative' }}
+    >
+      <div
+        style={{ padding: '16px', display: 'flex', flexDirection: 'column' }}
+      >
+        <label>Select which simulation to view</label>
+        <StyledSelect
+          onChange={(e: Event) => {
+            setSelectedSim(parseInt(e.target.value))
+          }}
+        >
+          {publishedSimulation.simulations.map(
+            (simulation: TSimulation, index) => (
+              <option
+                key={index}
+                value={index}
+                onSelect={() => setSelectedSim(index)}
+              >
+                {new Date(simulation.started).toLocaleString(
+                  navigator.language
+                )}
+              </option>
+            )
+          )}
+        </StyledSelect>
+        {publishedSimulation.simulations[selectedSim]?.result._id ? (
+          <Result
+            result={publishedSimulation.simulations[selectedSim]?.result}
+          />
+        ) : (
+          <div style={{ alignSelf: 'center' }}>
+            <label>No result for this simulation...</label>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/custom-plugins/forecast-of-response/src/utils/auth.tsx
+++ b/web/custom-plugins/forecast-of-response/src/utils/auth.tsx
@@ -1,0 +1,11 @@
+export function hasExpertRole(userData: any): boolean {
+  if (userData?.roles) {
+    if (
+      userData.roles.includes('EXPERT') ||
+      userData.roles.includes('DMSS_ADMIN')
+    ) {
+      return true
+    }
+  }
+  return false
+}


### PR DESCRIPTION
- Enable the "Publish Simulation" button
- Render different components based on application role (operator phase view)
- User Icon can be clicked to view access token information

closes #76 closes #75 closes #54