### PR TITLE
Augmented Phase.json to include a "workflow" attribute.

### DIFF
--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Phase.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Phase.json
@@ -25,6 +25,12 @@
       "optional": true
     },
     {
+      "name": "workflow",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
       "name": "end",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string",


### PR DESCRIPTION
In order to remote-run the SIMA stask, it is necessary to indentify both the workflowTask (task=...) and the workflow (workflow=..).