### PR TITLE
Correct type and fix order of required/optional params to createContainer call

### DIFF
--- a/api/home/for/data/ForecastDS/FoR-Data/Operations/operation1.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Operations/operation1.json
@@ -116,11 +116,6 @@
           "results": [
             {
               "type": "ForecastDS/FoR-BP/Blueprints/ResultFile",
-              "_id": "cf81daa9-9787-462e-b92b-104f71b80712",
-              "name": "ShouldBeRemoved_result"
-            },
-            {
-              "type": "ForecastDS/FoR-BP/Blueprints/ResultFile",
               "_id": "cf81daa9-9787-462e-b92b-104f71b80713",
               "name": "result_weather_data"
             }

--- a/web/custom-plugins/forecast-of-response/src/Types.ts
+++ b/web/custom-plugins/forecast-of-response/src/Types.ts
@@ -55,10 +55,19 @@ export type StringMap = {
   [key: string]: string
 }
 
+export type TJob = {
+  name: string
+  image: string
+  command: string[]
+  type: string
+  subnetId?: string
+  logAnalyticsWorkspaceResourceId?: string
+}
+
 export type TSimulationConfig = {
   name: string
   variables: TVariable[]
-  jobs: any[]
+  jobs: TJob[]
   results: any[]
   cronJob: any
   published: boolean

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
@@ -274,9 +274,9 @@ function SingleSimulationConfig(props: {
       `${DEFAULT_DATASOURCE_ID}/${stask._blob_id}`, // STask
       simaTask, //Sima task in STask
       simaWorkflow, // Sima workflow in task
-      true, // Use remote compute service
-      `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}`, // Id of compute cfg
       dottedId, // Reference to Sima job input entity
+      `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}`, // Id of compute cfg
+      true, // Use remote compute service
       `${DEFAULT_DATASOURCE_ID}/${dottedId}.results`, // Reference for results upload destination
       cronValue
     )
@@ -326,9 +326,9 @@ function SingleSimulationConfig(props: {
       `${DEFAULT_DATASOURCE_ID}/${stask._blob_id}`, // STask
       simaTask, //Sima task in STask
       simaWorkflow, // Sima workflow in task
-      true, // Use remote compute service
-      `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}`,
       dottedId, // Reference to Sima job input entity
+      `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}`,
+      true, // Use remote compute service
       `${DEFAULT_DATASOURCE_ID}/${dottedId}.results` // Reference for results upload destination
     )
     dmssAPI.generatedDmssApi

--- a/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
+++ b/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
@@ -1,4 +1,4 @@
-import { TCronJob, TSimulation } from '../Types'
+import { TCronJob, TJob } from '../Types'
 import { Blueprints } from '../Enums'
 import { poorMansUUID } from './uuid'
 import {
@@ -11,12 +11,12 @@ export function createContainerJob(
   staskBlobId: string,
   task: string,
   workflow: string,
-  remoteRun?: boolean = false,
-  computeServiceConfigBlobId?: string,
   inputId: string,
   targetId: string,
+  remoteRun: boolean = false,
+  computeServiceConfigBlobId?: string,
   cronJob?: TCronJob
-): TSimulation {
+): TJob {
   const runRemote: string[] = remoteRun
     ? ['--remote-run', `--compute-service-cfg=${computeServiceConfigBlobId}`]
     : []


### PR DESCRIPTION
Not entirely certain that this will fix the issue at hand, but seeing as I'm unable to reproduce it locally I figured we could push this suggested fix to determine whether it resolves the problem.