### PR TITLE
add result from job to an operation entity's results list

### DIFF
--- a/api/home/for/data/ForecastDS/FoR-Data/SIMACompute/compute.yml
+++ b/api/home/for/data/ForecastDS/FoR-Data/SIMACompute/compute.yml
@@ -1,9 +1,9 @@
 scs:
   name: "scs"
-  # Address to use when contacting the SIMA Compute Service using SSH tunnel
-  uri: http://st-lcmadm01.st.statoil.no:8088
+  # IP for http://st-lcmadm01.st.statoil.no:8088 to use when contacting the SIMA Compute Service using SSH tunnel
+  uri: "http://10.14.75.11:8088"
   # Remote address for the SIMA Compute Service – for users inside the firewall
-  url: http://st-lcmadm01.st.statoil.no:8088
+  url: "http://10.14.75.11:8088"
   username: ---
   password: ---
   max_concurrent_condition_runs: "16"

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
@@ -230,12 +230,16 @@ const OperationCreate = (): JSX.Element => {
         'name' in newOperationConfig &&
         'simaVersion' in newOperationConfig &&
         'phases' in newOperationConfig
-      if (hasRequiredAttirbutes) {
+      if (newOperationConfig['type'] !== Blueprints.CONFIG) {
+        setError(
+          `The configuration file has wrong type attribute. The type must be ${Blueprints.CONFIG}`
+        )
+      } else if (hasRequiredAttirbutes) {
         setError(undefined)
         setOperationConfig(newOperationConfig)
       } else {
         setError(
-          `Could not parse content of the configuration file ${filename}. Does the file have all required attributes?`
+          `Could not parse content of the configuration file ${filename}. Does the file have the required attributes 'name', 'simaVersion' and 'phases'?`
         )
       }
     }

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
@@ -258,6 +258,8 @@ function SingleSimulationConfig(props: {
   const jobAPI = new JobApi(token)
   const dmssAPI = new DmssAPI(token)
 
+  const result_dotted_id = `${dottedId}.results` //todo check if this is correct
+
   const addResultGraph = () => {
     const index: string = (Math.random() * 100).toString()
     setResultGraphs({ ...resultGraphs, [index]: true })
@@ -306,6 +308,7 @@ function SingleSimulationConfig(props: {
       dottedId, // Reference to Sima job input entity
       `${DEFAULT_DATASOURCE_ID}/${ENTITIES}/${RESULT_FOLDER_NAME}`, //folder where result file should be uploaded
       true, // Use remote compute service
+      result_dotted_id,
       `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}`, //id of compute config
       cronValue
     )
@@ -358,6 +361,7 @@ function SingleSimulationConfig(props: {
       dottedId, // Reference to Sima job input entity
       `${DEFAULT_DATASOURCE_ID}/${ENTITIES}/${RESULT_FOLDER_NAME}`, //folder where result file should be uploaded
       true, // Use remote compute service
+      result_dotted_id,
       `${DEFAULT_DATASOURCE_ID}/${configBlob._blob_id}` //id of compute config
     )
     dmssAPI.generatedDmssApi

--- a/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
+++ b/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
@@ -14,6 +14,7 @@ export function createContainerJob(
   inputId: string,
   targetFolder: string, //the folder to store result files
   remoteRun: boolean = false,
+  result_dotted_id: string,
   computeServiceConfigBlobId?: string,
   cronJob?: TCronJob
 ): TJob {
@@ -33,6 +34,7 @@ export function createContainerJob(
       `--workflow=${workflow}`,
       `--input=${DEFAULT_DATASOURCE_ID}/${inputId}`,
       `--target=${targetFolder}`,
+      `--operation-results-dotted-id=${result_dotted_id}`,
       ...runRemote,
     ],
     subnetId: AzureContainerInstancesOmniaSubnetId,

--- a/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
+++ b/web/custom-plugins/forecast-of-response/src/utils/createContainerJob.ts
@@ -14,7 +14,7 @@ export function createContainerJob(
   inputId: string,
   targetFolder: string, //the folder to store result files
   remoteRun: boolean = false,
-  result_dotted_id: string,
+  resultLinkTarget: string,
   computeServiceConfigBlobId?: string,
   cronJob?: TCronJob
 ): TJob {
@@ -34,7 +34,7 @@ export function createContainerJob(
       `--workflow=${workflow}`,
       `--input=${DEFAULT_DATASOURCE_ID}/${inputId}`,
       `--target=${targetFolder}`,
-      `--operation-results-dotted-id=${result_dotted_id}`,
+      `--result-link-target=${resultLinkTarget}`,
       ...runRemote,
     ],
     subnetId: AzureContainerInstancesOmniaSubnetId,


### PR DESCRIPTION
send the dotted path  of the operation entity's results list to the sre-wrapper, to be used in the upload() function in DMT/job_wrapper.py

not tested yet...

(must push new image of publicMSA.azurecr.io/dmt-job/srs:latest to make this work)

closes #172 