### PR TITLE
bugfix: result data gets deleted

### DIFF
--- a/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Comments.tsx
@@ -129,7 +129,7 @@ export const CommentInput = (props: {
       message: message,
     }
     setLoading(true)
-
+    //todo the functionality for adding new comment should be improved (note: using dmssAPI.explorerAdd cuased erors with deletion of result data for an operation)
     //upload the comment entity to the comment package
     addToPath(newComment, token, [], DEFAULT_DATASOURCE_ID, CommentPackage)
       .then((uid: string) => {

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
@@ -403,7 +403,6 @@ function SingleSimulationConfig(props: {
         setLoadingJob(false)
       })
   }
-
   return (
     <div
       style={{
@@ -526,7 +525,7 @@ function SingleSimulationConfig(props: {
         {results[selectedResult]?._id && (
           <Result
             result={results[selectedResult]}
-            addResultGraph={addPlotWindow}
+            addPlotWindow={addPlotWindow}
           />
         )}
         {resultGraphs &&
@@ -538,16 +537,6 @@ function SingleSimulationConfig(props: {
               deleteResultGraph={removePlotWindow}
             />
           ))}
-        <Button
-          style={{ width: '140px', marginLeft: '10px' }}
-          variant="outlined"
-          onClick={() => {
-            addPlotWindow()
-          }}
-        >
-          Add plot
-          <Icons name="add" title="add" />
-        </Button>
       </div>
     </div>
   )

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/PhaseView.tsx
@@ -151,6 +151,7 @@ function NewSimulationConfig(props: {
         dataSourceId: DEFAULT_DATASOURCE_ID,
         dottedId: `${dottedId}`,
         body: newSimConf,
+        updateUncontained: false,
       })
       .then(() => setSimulationConfigs([...simulationConfigs, newSimConf]))
       .catch((e: Error) => {

--- a/web/custom-plugins/forecast-of-response/src/components/Result.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Result.tsx
@@ -171,10 +171,11 @@ export type TGraphInfo = {
 
 export default (props: {
   result: any
+  addPlotWindow?: Function
   index?: string
   deleteResultGraph?: Function
 }) => {
-  const { result, index, deleteResultGraph } = props
+  const { result, addPlotWindow, index, deleteResultGraph } = props
   const [graphInfo, setGraphInfo] = useState<TGraphInfo[]>([])
   const [variableRuns, setVariableRuns] = useState<any[]>([])
   const [chartData, setChartData] = useState<TLineChartDataPoint[]>([])
@@ -212,37 +213,49 @@ export default (props: {
   }
 
   return (
-    <ResultWrapper>
-      <div>
-        <GraphSelect
-          variableRuns={variableRuns}
-          chartData={chartData}
-          setChartData={setChartData}
-          setGraphInfo={setGraphInfo}
-          graphInfo={graphInfo}
-          index={index}
-          deleteResultGraph={deleteResultGraph}
-        />
-        {graphInfo.length >= 1 && (
-          <AddedGraphWrapper>
-            {graphInfo.map((graph, index) => (
-              <Tooltip title={graph.description} key={index}>
-                <Chip
-                  key={index}
-                  style={{ margin: '10px 5px', cursor: 'help', zIndex: 1 }}
-                  variant="active"
-                  onDelete={() => removeGraph(graph.name)}
-                >
-                  <IconWrapper color={plotColors[index]}>&#9679;</IconWrapper>
-                  {graph.name}
-                </Chip>
-              </Tooltip>
-            ))}
-          </AddedGraphWrapper>
-        )}
-      </div>
-      <LinesOverTime data={chartData} graphInfo={graphInfo} />
-      <ArrowPlots data={chartData} graphInfo={graphInfo} />
-    </ResultWrapper>
+    <div>
+      <ResultWrapper>
+        <div>
+          <GraphSelect
+            variableRuns={variableRuns}
+            chartData={chartData}
+            setChartData={setChartData}
+            setGraphInfo={setGraphInfo}
+            graphInfo={graphInfo}
+            index={index}
+            deleteResultGraph={deleteResultGraph}
+          />
+          {graphInfo.length >= 1 && (
+            <AddedGraphWrapper>
+              {graphInfo.map((graph, index) => (
+                <Tooltip title={graph.description} key={index}>
+                  <Chip
+                    key={index}
+                    style={{ margin: '10px 5px', cursor: 'help', zIndex: 1 }}
+                    variant="active"
+                    onDelete={() => removeGraph(graph.name)}
+                  >
+                    <IconWrapper color={plotColors[index]}>&#9679;</IconWrapper>
+                    {graph.name}
+                  </Chip>
+                </Tooltip>
+              ))}
+            </AddedGraphWrapper>
+          )}
+        </div>
+        <LinesOverTime data={chartData} graphInfo={graphInfo} />
+        <ArrowPlots data={chartData} graphInfo={graphInfo} />
+      </ResultWrapper>
+      {addPlotWindow && (
+        <Button
+          style={{ width: '140px', marginLeft: '10px' }}
+          variant="outlined"
+          onClick={() => addPlotWindow()}
+        >
+          Add plot
+          <Icons name="add" title="add" />
+        </Button>
+      )}
+    </div>
   )
 }

--- a/web/custom-plugins/forecast-of-response/src/const.ts
+++ b/web/custom-plugins/forecast-of-response/src/const.ts
@@ -1,10 +1,11 @@
 export const DEFAULT_DATASOURCE_ID = 'ForecastDS'
 export const BLUEPRINTS = 'FoR-BP'
 export const ENTITIES = 'FoR-Data'
-export const LocationPackage = 'FoR-Data/Locations'
-export const ConfigsPackage = 'FoR-Data/Configs'
+export const LocationPackage = `${ENTITIES}/Locations`
+export const ConfigsPackage = `${ENTITIES}/Configs`
+export const CommentPackage = `${ENTITIES}/Comments`
 export const RESULT_FOLDER_NAME = 'Results'
-export const OperationsLocation = 'FoR-Data/Operations'
+export const OperationsLocation = `${ENTITIES}/Operations`
 export const AzureContainerInstancesOmniaSubnetId =
   '/subscriptions/93b83577-619d-4fb9-bfdf-f7a07d24cfbe/resourceGroups/S059-NOE-network/providers/Microsoft.Network/virtualNetworks/S059-NOE-vnet/subnets/S059-NOE-container-instances'
 export const AzureContainerInstancesOmniaLogAnalyticsWorkspaceResourceId =


### PR DESCRIPTION
use updateUncontained = false in explorerAdd. Without this change, the content of a result entity gets deleted.

Updated the way comments are added - first upload a comment entity to the comments package,  and then add reference to the comment in the operation entity.
(   also tried to set updateUncontained = false when uploading comments in the old code, but this did not work) 



Also: moved add plot button into the result component to hide the button when no results are available

closes #173 