### PR TITLE
operation comments are a storage uncontained (allows for separate ACL)

### DIFF
--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Comment.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Comment.json
@@ -1,8 +1,8 @@
 {
   "name": "Comment",
   "type": "system/SIMOS/Blueprint",
-  "extends": ["system/SIMOS/DefaultUiRecipes","system/SIMOS/NamedEntity"],
-  "description": "Operation comments",
+  "extends": ["system/SIMOS/DefaultUiRecipes"],
+  "description": "A comment on a message board",
   "attributes": [
     {
       "name": "author",
@@ -19,6 +19,5 @@
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string"
     }
-  ],
-    "uiRecipes": []
+  ]
 }

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Comments.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Comments.json
@@ -1,0 +1,18 @@
+{
+  "name": "Comments",
+  "type": "system/SIMOS/Blueprint",
+  "description": "Operation comments.",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "comments",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Comment",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ComparisonGroups.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ComparisonGroups.json
@@ -1,17 +1,17 @@
 {
- "name" : "ComparisonGroups",
- "type" : "system/SIMOS/Blueprint",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "parameterVariations",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/ParameterVariations",
-   "dimensions" : "*",
-   "contained" : true,
-   "optional" : false
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "ComparisonGroups",
+  "type": "system/SIMOS/Blueprint",
+  "abstract": false,
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "parameterVariations",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/ParameterVariations",
+      "dimensions": "*",
+      "contained": true,
+      "optional": false
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Config.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Config.json
@@ -1,7 +1,7 @@
 {
   "name": "Config",
   "type": "system/SIMOS/Blueprint",
-  "extends": ["system/SIMOS/DefaultUiRecipes","system/SIMOS/NamedEntity"],
+  "extends": ["system/SIMOS/DefaultUiRecipes", "system/SIMOS/NamedEntity"],
   "description": "Configuration for operations",
   "attributes": [
     {
@@ -15,6 +15,5 @@
       "attributeType": "/Blueprints/Phase",
       "dimensions": "*"
     }
-  ],
-    "uiRecipes": []
+  ]
 }

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Location.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Location.json
@@ -1,7 +1,7 @@
 {
   "name": "Location",
   "type": "system/SIMOS/Blueprint",
-  "extends": ["system/SIMOS/DefaultUiRecipes","system/SIMOS/NamedEntity"],
+  "extends": ["system/SIMOS/DefaultUiRecipes", "system/SIMOS/NamedEntity"],
   "description": "Coordinates for a geographical location",
   "attributes": [
     {

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Operation.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Operation.json
@@ -54,13 +54,12 @@
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
       "optional": true
-    },{
+    }, {
       "name": "comments",
       "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "/Blueprints/Comment",
+      "attributeType": "/Blueprints/Comments",
       "optional": true,
-      "contained": false,
-      "dimensions": "*"
+      "contained": true
     }
   ],
   "uiRecipes": [
@@ -73,6 +72,25 @@
       "name": "OperationEdit",
       "plugin": "for-operation-edit",
       "type": "system/SIMOS/UiRecipe"
+    }
+  ],
+  "storageRecipes": [
+    {
+      "type": "system/SIMOS/StorageRecipe",
+      "name": "DEFAULT",
+      "description": "",
+      "attributes": [
+        {
+          "name": "comments",
+          "type": "/Blueprints/Comments",
+          "contained": false
+        },
+        {
+          "name": "location",
+          "type": "/Blueprints/Comments",
+          "contained": false
+        }
+      ]
     }
   ]
 }

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ParameterVariations.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ParameterVariations.json
@@ -1,24 +1,24 @@
 {
- "name" : "ParameterVariations",
- "type" : "system/SIMOS/Blueprint",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "variableRuns",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/VariableRun",
-   "contained" : false,
-   "optional" : false,
-   "description" : "uncontained list of variable runs"
-  }, {
-   "name" : "parameters",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/Variable",
-   "contained" : true,
-   "optional" : true,
-   "description" : "the variable value is a semi-colon separated list of parameters. Name and unit (and values) must correspond to the variables in the associated VariableRun"
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "ParameterVariations",
+  "type": "system/SIMOS/Blueprint",
+  "abstract": false,
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "variableRuns",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/VariableRun",
+      "contained": false,
+      "optional": false,
+      "description": "uncontained list of variable runs"
+    }, {
+      "name": "parameters",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Variable",
+      "contained": true,
+      "optional": true,
+      "description": "the variable value is a semi-colon separated list of parameters. Name and unit (and values) must correspond to the variables in the associated VariableRun"
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Response.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Response.json
@@ -1,17 +1,17 @@
 {
- "name" : "Response",
- "type" : "system/SIMOS/Blueprint",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "statistics",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/Timeseries",
-   "dimensions" : "*",
-   "contained" : true,
-   "optional" : false
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "Response",
+  "type": "system/SIMOS/Blueprint",
+  "abstract": false,
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "statistics",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Timeseries",
+      "dimensions": "*",
+      "contained": true,
+      "optional": false
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ResultFile.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/ResultFile.json
@@ -26,7 +26,7 @@
       "dimensions": "*",
       "contained": true,
       "optional": true
-    }    
+    }
   ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Threshold.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Threshold.json
@@ -1,24 +1,23 @@
 {
- "name" : "Threshold",
- "type" : "system/SIMOS/Blueprint",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "max",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "number",
-   "default" : "0.0"
-  }, {
-   "name" : "min",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "number",
-   "default" : "0.0"
-  }, {
-   "name" : "unit",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "string"
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "Threshold",
+  "type": "system/SIMOS/Blueprint",
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "max",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "default": "0.0"
+    }, {
+      "name": "min",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "default": "0.0"
+    }, {
+      "name": "unit",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Variable.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Variable.json
@@ -1,22 +1,21 @@
 {
- "name" : "Variable",
- "type" : "system/SIMOS/Blueprint",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "value",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "string"
-  }, {
-   "name" : "valueType",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "string"
-  }, {
-   "name" : "unit",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "string"
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "Variable",
+  "type": "system/SIMOS/Blueprint",
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }, {
+      "name": "valueType",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }, {
+      "name": "unit",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/VariableRun.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/VariableRun.json
@@ -1,26 +1,25 @@
 {
- "name" : "VariableRun",
- "type" : "system/SIMOS/Blueprint",
- "description" : "Results from a simulation corresponding to a set of key:value variables (\"no variations\")",
- "abstract" : false,
- "extends" : ["system/SIMOS/NamedEntity"],
- "attributes" : [{
-   "name" : "responses",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/Response",
-   "dimensions" : "*",
-   "contained" : true,
-   "optional" : false,
-   "description" : "a list of responses, where each response can have a number of timeseries which relate to its statistics e.g. mean response, max response etc..."
-  }, {
-   "name" : "variables",
-   "type" : "system/SIMOS/BlueprintAttribute",
-   "attributeType" : "/Blueprints/Variable",
-   "dimensions" : "*",
-   "contained" : true,
-   "optional" : false
-  }],
- "storageRecipes" : [],
- "uiRecipes" : []
+  "name": "VariableRun",
+  "type": "system/SIMOS/Blueprint",
+  "description": "Results from a simulation corresponding to a set of key:value variables (\"no variations\")",
+  "extends": ["system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "responses",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Response",
+      "dimensions": "*",
+      "contained": true,
+      "optional": false,
+      "description": "a list of responses, where each response can have a number of timeseries which relate to its statistics e.g. mean response, max response etc..."
+    }, {
+      "name": "variables",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Blueprints/Variable",
+      "dimensions": "*",
+      "contained": true,
+      "optional": false
+    }
+  ]
 }
 

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/MoveWindRing2020Comments.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/MoveWindRing2020Comments.json
@@ -1,0 +1,19 @@
+{
+  "_id": "MoveWindRig2020Comments",
+  "name": "MoveWindRig2020Comments",
+  "type": "ForecastDS/FoR-BP/Blueprints/Comments",
+  "comments": [
+    {
+      "type": "ForecastDS/FoR-BP/Blueprints/Comment",
+      "author": "kkje",
+      "date": "2021-06-25 13:45:37.352574",
+      "message": "Cool app bro!"
+    },
+    {
+      "type": "ForecastDS/FoR-BP/Blueprints/Comment",
+      "author": "stoo",
+      "date": "2021-06-25 13:45:37.352574",
+      "message": "Integer tristique et est eget tincidunt. Integer tristique et est eget tincidunt. MaInteger tristique et est eget tincidunt. Mauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusuris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusMauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
+    }
+  ]
+}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/SverdrupAnchorReplace2021Comments.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/SverdrupAnchorReplace2021Comments.json
@@ -1,0 +1,19 @@
+{
+  "_id": "SverdrupAnchorReplace2021Comments",
+  "name": "SverdrupAnchorReplace2021Comments",
+  "type": "ForecastDS/FoR-BP/Blueprints/Comments",
+  "comments": [
+    {
+      "type": "ForecastDS/FoR-BP/Blueprints/Comment",
+      "author": "netr0m",
+      "date": "2021-06-25 13:45:37.352574",
+      "message": "Integer tristique et est eget tincidunt. Mauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
+    },
+    {
+      "type": "ForecastDS/FoR-BP/Blueprints/Comment",
+      "author": "stoo",
+      "date": "2021-06-25 13:45:37.352574",
+      "message": "Integer tristique et est eget tincidunt. Integer tristique et est eget tincidunt. MaInteger tristique et est eget tincidunt. Mauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusuris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusMauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
+    }
+  ]
+}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/comment1.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/comment1.json
@@ -1,8 +1,0 @@
-{
-  "_id": "comment1",
-  "name": "comment1",
-  "type": "ForecastDS/FoR-BP/Blueprints/Comment",
-  "author": "eaks",
-  "date": "2021-06-25 13:45:37.352574",
-  "message": "Ongoing"
-}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/comment2.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/comment2.json
@@ -1,8 +1,0 @@
-{
-  "_id": "comment2",
-  "name": "comment2",
-  "type": "ForecastDS/FoR-BP/Blueprints/Comment",
-  "author": "netr0m",
-  "date": "2021-06-25 13:45:37.352574",
-  "message": "Integer tristique et est eget tincidunt. Mauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
-}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/comment3.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/comment3.json
@@ -1,8 +1,0 @@
-{
-  "_id": "comment3",
-  "name": "comment3",
-  "type": "ForecastDS/FoR-BP/Blueprints/Comment",
-  "author": "stoo",
-  "date": "2021-06-25 13:45:37.352574",
-  "message": "Integer tristique et est eget tincidunt. Integer tristique et est eget tincidunt. MaInteger tristique et est eget tincidunt. Mauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusuris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metusMauris mattis ultrices orci quis vulputate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
-}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/comment4.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/comment4.json
@@ -1,8 +1,0 @@
-{
-  "_id": "comment4",
-  "name": "comment4",
-  "type": "ForecastDS/FoR-BP/Blueprints/Comment",
-  "author": "kkje",
-  "date": "2021-06-25 13:45:37.352574",
-  "message": "Cool app bro!"
-}

--- a/api/home/for/data/ForecastDS/FoR-Data/Comments/comment5.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Comments/comment5.json
@@ -1,8 +1,0 @@
-{
-  "_id": "comment5",
-  "name": "comment5",
-  "type": "ForecastDS/FoR-BP/Blueprints/Comment",
-  "author": "netr0m",
-  "date": "2021-06-25 13:45:37.352574",
-  "message": "Integer trttis ultutate. Praesent enim magna, pulvinar ut eleifend eu, ornare nec arcu. Duis id magna vel leo venenatis interdum at iaculis enim. Quisque eu iaculis nibh. Curabitur et metus"
-}

--- a/api/home/for/data/ForecastDS/FoR-Data/Operations/operation1.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Operations/operation1.json
@@ -10,9 +10,9 @@
     "_blob_id": "a1fb7672-a559-4c5f-913c-281e142e7f0c"
   },
   "stask": {
-      "name": "/STasks/mymodel_2_lbje.stask",
-      "type": "system/SIMOS/Blob",
-      "_blob_id": "04cf2783-6118-4bfd-a427-9485b00fa9da"
+    "name": "/STasks/mymodel_2_lbje.stask",
+    "type": "system/SIMOS/Blob",
+    "_blob_id": "04cf2783-6118-4bfd-a427-9485b00fa9da"
   },
   "creator": "eaks",
   "location": {
@@ -23,30 +23,11 @@
   "start": "2021-06-25 13:45:37.352574",
   "end": "2021-06-27 13:45:37.352574",
   "status": "Ongoing",
-  "comments": [
-    {
-      "_id": "comment1",
-      "name": "comment1",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }, {
-      "_id": "comment2",
-      "name": "comment2",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }, {
-      "_id": "comment3",
-      "name": "comment3",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }, {
-      "_id": "comment4",
-      "name": "comment4",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    },
-    {
-      "_id": "comment5",
-      "name": "comment5",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }
-  ],
+  "comments": {
+    "_id": "SverdrupAnchorReplace2021Comments",
+    "name": "SverdrupAnchorReplace2021Comments",
+    "type": "ForecastDS/FoR-BP/Blueprints/Comments"
+  },
   "phases": [
     {
       "name": "the-first_phase",

--- a/api/home/for/data/ForecastDS/FoR-Data/Operations/operation2.json
+++ b/api/home/for/data/ForecastDS/FoR-Data/Operations/operation2.json
@@ -5,9 +5,9 @@
   "type": "ForecastDS/FoR-BP/Blueprints/Operation",
   "description": "an example operation",
   "stask": {
-      "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d5",
-      "name": "/STasks/mymodel_2_lbje.stask",
-      "type": "system/SIMOS/Blob"
+    "_id": "26a4d888-3ab4-4ad2-9bd9-9614dcb066d5",
+    "name": "/STasks/mymodel_2_lbje.stask",
+    "type": "system/SIMOS/Blob"
   },
   "creator": "KKJE",
   "location": {
@@ -18,16 +18,10 @@
   "start": "2020-07-25 13:45:37.352574",
   "end": "2020-09-14 13:45:37.352574",
   "status": "Upcoming",
-  "comments": [
-    {
-      "_id": "comment1",
-      "name": "comment1",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }, {
-      "_id": "comment2",
-      "name": "comment2",
-      "type": "ForecastDS/FoR-BP/Blueprints/Comment"
-    }
-  ],
+  "comments": {
+    "_id": "MoveWindRig2020Comments",
+    "name": "MoveWindRig2020Comments",
+    "type": "ForecastDS/FoR-BP/Blueprints/Comments"
+  },
   "phases": []
 }

--- a/web/custom-plugins/forecast-of-response/src/Enums.ts
+++ b/web/custom-plugins/forecast-of-response/src/Enums.ts
@@ -21,6 +21,7 @@ export enum ACLEnum {
 export enum Blueprints {
   OPERATION = 'ForecastDS/FoR-BP/Blueprints/Operation',
   Comment = 'ForecastDS/FoR-BP/Blueprints/Comment',
+  Comments = 'ForecastDS/FoR-BP/Blueprints/Comments',
   SIMULATION = 'ForecastDS/FoR-BP/Blueprints/Simulation',
   SIMULATION_CONFIG = 'ForecastDS/FoR-BP/Blueprints/SimulationConfig',
   VARIABLE = 'ForecastDS/FoR-BP/Blueprints/Variable',
@@ -31,4 +32,5 @@ export enum Blueprints {
   LOCATION = 'ForecastDS/FoR-BP/Blueprints/Location',
   STASK = 'ForecastDS/FoR-BP/Blueprints/STask',
   CONFIG = 'ForecastDS/FoR-BP/Blueprints/Config',
+  BLOB = 'system/SIMOS/Blob',
 }

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationCreate.tsx
@@ -104,7 +104,7 @@ const createOperationEntity = (
     type: Blueprints.OPERATION,
     stask: {
       name: stask.name,
-      type: 'system/SIMOS/Blob',
+      type: Blueprints.BLOB,
     },
     creator: user,
     location: location,
@@ -112,6 +112,11 @@ const createOperationEntity = (
     end: dateRange && dateRange[1] ? dateRange[1].toISOString() : undefined,
     status: OperationStatus.UPCOMING, // TODO: decide based on start attr? allow user to select?
     phases: config.phases,
+    comments: {
+      name: operationName,
+      type: Blueprints.Comments,
+      comments: [],
+    },
   }
   if (SIMACompute)
     body.SIMAComputeConnectInfo = {
@@ -141,11 +146,13 @@ const onClickCreate = (
 ) => {
   setLoading(true)
   const getIds = []
+
   // Prepare the uncontained entities for the Operation
   operationLocation.type = Blueprints.LOCATION
   getIds.push(
     getEntityId(operationLocation, token, isNewEntity.location, LocationPackage)
   )
+
   if (operationConfig) {
     // Optional
     operationConfig.type = Blueprints.CONFIG
@@ -168,7 +175,9 @@ const onClickCreate = (
       )
     })
   }
+
   setLoading(true)
+
   Promise.all(getIds)
     .then((documentIds: string[]) => {
       if (isNewEntity.location) operationLocation._id = documentIds[0]

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
@@ -50,12 +50,10 @@ const CommentsWrapper = styled.div`
 export default (props: { operation: TOperation }): JSX.Element => {
   const { operation } = props
   const [viewACL, setViewACL] = useState<boolean>(false)
-  const [comments, setComments] = useState<TComment[]>(operation.comments)
+  const [comments, setComments] = useState<TComment[]>(
+    operation.comments?.comments
+  )
   const { tokenData } = useContext(AuthContext)
-
-  const updateComments = (newComment: TComment) => {
-    setComments([...comments, newComment])
-  }
 
   return (
     <Card style={{ maxWidth: '1200px' }}>
@@ -193,8 +191,10 @@ export default (props: { operation: TOperation }): JSX.Element => {
         ))}
       </CommentsWrapper>
       <CommentInput
-        operationId={operation._id}
-        handleNewComment={updateComments}
+        commentsId={operation.comments._id}
+        handleNewComment={(newComment: TComment) =>
+          setComments([...comments, newComment])
+        }
       />
     </Card>
   )

--- a/web/custom-plugins/forecast-of-response/src/const.ts
+++ b/web/custom-plugins/forecast-of-response/src/const.ts
@@ -3,7 +3,6 @@ export const BLUEPRINTS = 'FoR-BP'
 export const ENTITIES = 'FoR-Data'
 export const LocationPackage = `${ENTITIES}/Locations`
 export const ConfigsPackage = `${ENTITIES}/Configs`
-export const CommentPackage = `${ENTITIES}/Comments`
 export const RESULT_FOLDER_NAME = 'Results'
 export const OperationsLocation = `${ENTITIES}/Operations`
 export const AzureContainerInstancesOmniaSubnetId =


### PR DESCRIPTION
- Create a wrapper blueprint for the list of comments
- Set the comments as storage uncontained
- The owner can now edit ACL for this entity isolated from the rest of the operation (grant all write etc.)

- Some json formating

closes #183 