### PR TITLE
derive status from date range

### DIFF
--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Operation.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Operation.json
@@ -50,11 +50,6 @@
       "optional": true
     },
     {
-      "name": "status",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    }, {
       "name": "comments",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "/Blueprints/Comments",

--- a/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Phase.json
+++ b/api/home/for/data/ForecastDS/FoR-BP/Blueprints/Phase.json
@@ -37,13 +37,6 @@
       "optional": true
     },
     {
-      "name": "status",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "Upcoming",
-      "optional": true
-    },
-    {
       "name": "defaultVariables",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "/Blueprints/Variable",

--- a/web/custom-plugins/forecast-of-response/src/Enums.ts
+++ b/web/custom-plugins/forecast-of-response/src/Enums.ts
@@ -2,6 +2,7 @@ export enum OperationStatus {
   UPCOMING = 'Upcoming',
   ONGOING = 'Ongoing',
   CONCLUDED = 'Concluded',
+  UNKNOWN = 'Unknown',
 }
 
 export enum SimulationStatus {

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationOverview.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationOverview.tsx
@@ -11,6 +11,7 @@ import DateRangePicker from '../components/DateRangePicker'
 import Grid from '../components/App/Grid'
 import { Blueprints, OperationStatus } from '../Enums'
 import { getUsername, hasExpertRole } from '../utils/auth'
+import { statusFromDates } from '../utils/statusFromDates'
 
 const GridContainer = styled.div`
   padding-top: 50px;
@@ -49,17 +50,20 @@ const OperationOverview = (props: DmtSettings): JSX.Element => {
       case OperationStatus.ONGOING:
         return allOperations.filter(
           (operation: TOperation) =>
-            operation.status === OperationStatus.ONGOING
+            OperationStatus.ONGOING ===
+            statusFromDates(operation.start, operation.end)
         )
       case OperationStatus.UPCOMING:
         return allOperations.filter(
           (operation: TOperation) =>
-            operation.status === OperationStatus.UPCOMING
+            OperationStatus.UPCOMING ===
+            statusFromDates(operation.start, operation.end)
         )
       case OperationStatus.CONCLUDED:
         return allOperations.filter(
           (operation: TOperation) =>
-            operation.status === OperationStatus.CONCLUDED
+            OperationStatus.CONCLUDED ===
+            statusFromDates(operation.start, operation.end)
         )
       case 'My operations':
         return allOperations.filter((operation: TOperation) => {

--- a/web/custom-plugins/forecast-of-response/src/Pages/OperationView.tsx
+++ b/web/custom-plugins/forecast-of-response/src/Pages/OperationView.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { AuthContext, useDocument } from '@dmt/common'
-import { Progress, Tabs } from '@equinor/eds-core-react'
+import { Progress, Tabs, Typography } from '@equinor/eds-core-react'
 import { TOperation, TPhase } from '../Types'
 import OperationDetails from '../components/Operations/OperationDetails'
 import PhaseView from '../components/Operations/PhaseView'
@@ -39,6 +39,7 @@ export default (): JSX.Element => {
 
   return (
     <>
+      <Typography variant="body_long">{operation.name}</Typography>
       <Tabs
         activeTab={activeTab}
         onChange={(index: number) => setActiveTab(index)}
@@ -56,7 +57,10 @@ export default (): JSX.Element => {
         </Tabs.List>
         <Tabs.Panels>
           <Tabs.Panel>
-            <OperationDetails operation={operation} />
+            <OperationDetails
+              operation={operation}
+              setActiveTab={setActiveTab}
+            />
           </Tabs.Panel>
           {phases.length ? (
             phases.map((phase: TPhase, index: number) => (

--- a/web/custom-plugins/forecast-of-response/src/Types.ts
+++ b/web/custom-plugins/forecast-of-response/src/Types.ts
@@ -99,9 +99,8 @@ export type TPhase = {
   name: string
   workflowTask: string
   workflow: string
-  start?: Date
-  end?: Date
-  status?: OperationStatus
+  start?: string
+  end?: string
   defaultVariables?: TVariable
 }
 
@@ -128,9 +127,8 @@ export type TOperation = {
   SIMAComputeConnectInfo: TBlob
   description?: string
   creator: string
-  start?: Date
-  end?: Date
-  status?: OperationStatus
+  start?: string
+  end?: string
   location: TLocation
   phases: TPhase[]
   comments?: TComment

--- a/web/custom-plugins/forecast-of-response/src/components/Design/Icons.ts
+++ b/web/custom-plugins/forecast-of-response/src/components/Design/Icons.ts
@@ -1,6 +1,7 @@
 import { Icon } from '@equinor/eds-core-react'
 import {
   accessible,
+  assignment_user,
   account_circle,
   add_circle_outlined,
   delete_forever,
@@ -28,6 +29,7 @@ import {
 } from '@equinor/eds-icons'
 
 Icon.add({
+  assignment_user,
   waves,
   notifications,
   account_circle,

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationDetails.tsx
@@ -1,16 +1,7 @@
 import React, { useContext, useState } from 'react'
 import { TOperation } from '../Types'
-import { getUsername } from '../../utils/auth'
-import {
-  Button,
-  Card,
-  Label,
-  Scrim,
-  Table,
-  Typography,
-  Dialog,
-  Icon,
-} from '@equinor/eds-core-react'
+import { getUsername, hasExpertRole } from '../../utils/auth'
+import { Button, Card, Label, Table, Typography } from '@equinor/eds-core-react'
 import { StatusDot } from '../Other'
 import styled from 'styled-components'
 import { LocationOnMap } from '../Map'
@@ -18,9 +9,9 @@ import { TComment, TPhase } from '../../Types'
 import { CommentInput, CommentView } from '../Comments'
 import { AccessControlList, AuthContext } from '@dmt/common'
 import { DEFAULT_DATASOURCE_ID } from '../../const'
-import { hasExpertRole } from '../../utils/auth'
-import { ClickableIcon } from '../App/Header'
 import { CustomScrim } from '../CustomScrim'
+import { statusFromDates } from '../../utils/statusFromDates'
+import Icons from '../Design/Icons'
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -47,8 +38,11 @@ const CommentsWrapper = styled.div`
   padding: 5px;
 `
 
-export default (props: { operation: TOperation }): JSX.Element => {
-  const { operation } = props
+export default (props: {
+  operation: TOperation
+  setActiveTab: Function
+}): JSX.Element => {
+  const { operation, setActiveTab } = props
   const [viewACL, setViewACL] = useState<boolean>(false)
   const [comments, setComments] = useState<TComment[]>(
     operation.comments?.comments
@@ -89,8 +83,10 @@ export default (props: { operation: TOperation }): JSX.Element => {
           </FlexWrapper>
           <FlexWrapper>
             <Label label="Status:" />
-            {operation.status}
-            <StatusDot status={operation.status} />
+            {statusFromDates(operation.start, operation.end)}
+            <StatusDot
+              status={statusFromDates(operation.start, operation.end)}
+            />
           </FlexWrapper>
           <FlexWrapper>
             <Label label="STask:" />
@@ -114,7 +110,8 @@ export default (props: { operation: TOperation }): JSX.Element => {
               setViewACL(!viewACL)
             }}
           >
-            Open access panel
+            Access control
+            <Icons name="assignment_user" title="assignment_user" />
           </Button>
         )}
       </Card.Actions>
@@ -144,7 +141,11 @@ export default (props: { operation: TOperation }): JSX.Element => {
         <Table.Body>
           {operation.phases.length ? (
             operation.phases.map((phase: TPhase, index: number) => (
-              <Table.Row key={index}>
+              <Table.Row
+                key={index}
+                style={{ cursor: 'pointer' }}
+                onClick={() => setActiveTab(index + 1)}
+              >
                 <Table.Cell>{phase.name}</Table.Cell>
                 <Table.Cell>
                   {phase.start
@@ -158,8 +159,10 @@ export default (props: { operation: TOperation }): JSX.Element => {
                 </Table.Cell>
                 <Table.Cell>
                   <FlexWrapper>
-                    {phase.status}
-                    <StatusDot status={phase.status} />
+                    {statusFromDates(phase.start, phase.end)}
+                    <StatusDot
+                      status={statusFromDates(phase.start, phase.end)}
+                    />
                   </FlexWrapper>
                 </Table.Cell>
               </Table.Row>

--- a/web/custom-plugins/forecast-of-response/src/components/Operations/OperationsTable.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Operations/OperationsTable.tsx
@@ -3,6 +3,7 @@ import DynamicTable from '../DynamicTable'
 import { DmtSettings, TOperation } from '../../Types'
 import { OperationStatus } from '../../Enums'
 import { DEFAULT_DATASOURCE_ID } from '../../const'
+import { statusFromDates } from '../../utils/statusFromDates'
 
 const columns: Array<string> = [
   'Operation name',
@@ -51,7 +52,7 @@ const OperationsTable = (props: {
       end: endDate,
       location: operation.location.name,
       creator: operation.creator,
-      status: operation.status,
+      status: statusFromDates(operation.start, operation.end),
     }
     rows.push(row)
   })

--- a/web/custom-plugins/forecast-of-response/src/utils/statusFromDates.ts
+++ b/web/custom-plugins/forecast-of-response/src/utils/statusFromDates.ts
@@ -1,0 +1,17 @@
+import { OperationStatus } from '../Enums'
+
+export function statusFromDates(
+  start: string | undefined,
+  end: string | undefined
+): OperationStatus {
+  if (start === undefined || end === undefined) return OperationStatus.UNKNOWN
+
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  const now = new Date()
+
+  if (endDate < now) return OperationStatus.CONCLUDED
+  if (startDate > now) return OperationStatus.UPCOMING
+
+  return OperationStatus.ONGOING
+}


### PR DESCRIPTION
- Derive operation/phase status from date range
- remove "status" from blueprints and types
-  Header that show operation name when browsing phase tabs
-  Icon on "Access contol"
- Clickable phase table rows in operation details (same as clicking tab)

closes #203 
