### PR TITLE
Updated Results.tsx to address Issue 217

### DIFF
--- a/web/custom-plugins/forecast-of-response/src/components/Plots/LinesOverTime.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Plots/LinesOverTime.tsx
@@ -29,8 +29,9 @@ export default (props: {
   const victoryTooltip = (
     <VictoryTooltip
       style={{ fontSize: fontSize }}
-      pointerLength={-60}
+      pointerLength={5}
       centerOffset={{ y: -10 }}
+      constrainToVisibleArea
       flyoutPadding={({ text }) =>
         text.length > 1 ? { top: 10, bottom: 10, left: 15, right: 15 } : 7
       }
@@ -107,7 +108,7 @@ export default (props: {
         width={chartWidth}
         height={plotHeight}
         theme={VictoryTheme.material}
-        domainPadding={{ y: 20 }}
+        domainPadding={{ y: 45 }}
         padding={{ top: 5, bottom: 25, right: 5, left: 55 }}
         containerComponent={
           <VictoryVoronoiContainer

--- a/web/custom-plugins/forecast-of-response/src/components/Result.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Result.tsx
@@ -334,9 +334,7 @@ export default (props: {
           {graphInfo.length >= 1 && (
             <AddedGraphWrapper>
               {graphInfo.map((graph: TGraphInfo, graphIndex) => (
-                <Tooltip 
-                  placement="auto" 
-                  title={graph.description} key={graphIndex}>
+                <Tooltip title={graph.description} key={graphIndex}>
                   <Chip
                     key={graphIndex}
                     style={{ margin: '10px 5px', cursor: 'help', zIndex: 1 }}

--- a/web/custom-plugins/forecast-of-response/src/components/Result.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Result.tsx
@@ -334,7 +334,7 @@ export default (props: {
           {graphInfo.length >= 1 && (
             <AddedGraphWrapper>
               {graphInfo.map((graph: TGraphInfo, graphIndex) => (
-                <Tooltip title={graph.description} key={graphIndex}>
+                <Tooltip placement="auto" title={graph.description} key={graphIndex}>
                   <Chip
                     key={graphIndex}
                     style={{ margin: '10px 5px', cursor: 'help', zIndex: 1 }}

--- a/web/custom-plugins/forecast-of-response/src/components/Result.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Result.tsx
@@ -334,7 +334,9 @@ export default (props: {
           {graphInfo.length >= 1 && (
             <AddedGraphWrapper>
               {graphInfo.map((graph: TGraphInfo, graphIndex) => (
-                <Tooltip placement="auto" title={graph.description} key={graphIndex}>
+                <Tooltip 
+                  placement="auto" 
+                  title={graph.description} key={graphIndex}>
                   <Chip
                     key={graphIndex}
                     style={{ margin: '10px 5px', cursor: 'help', zIndex: 1 }}


### PR DESCRIPTION
Added placement keyword to address Issue 217. Default placement is bottom
(https://eds-storybook-react.azurewebsites.net/?path=/docs/data-display-tooltip--default)
This seems consistent with the issue 217. 

Attempting placement="auto". The hope is that this will place the Tooltip within the plot view for all points. However, I have not been able to test this, so it may not help.