### PR TITLE
set max width for arrow plot

### DIFF
--- a/web/custom-plugins/forecast-of-response/src/components/Plots/ArrowPlots.tsx
+++ b/web/custom-plugins/forecast-of-response/src/components/Plots/ArrowPlots.tsx
@@ -56,11 +56,7 @@ export default (props: {
   const arrowPlotHeight: number = 60
 
   return (
-    <div
-      style={{
-        width: '100%',
-      }}
-    >
+    <div style={{ width: '100%', maxWidth: '1270px' }}>
       {graphInfo &&
         graphInfo.map((graphInfo: TGraphInfo, index) => {
           if (graphInfo.plotType === PlotType.ARROW) {
@@ -100,6 +96,7 @@ export default (props: {
                   }}
                   labelComponent={
                     <VictoryTooltip
+                      style={{ fontSize: '7px' }}
                       y={tooltipOffset}
                       flyoutPadding={({ text }) =>
                         text.length > 1


### PR DESCRIPTION
plot looks good when web page window size displaying plot is > 1270 px, but narrower window size causes a gap to the right of the arrow plot.

I was not able to solve this... The interface for VictoryChart is very difficult to use for UI changes like this. Didn't want to spend too much time on it....

![image](https://user-images.githubusercontent.com/69512295/150953321-b2fb8ed9-3e9c-4b7b-a668-d16462406698.png)

![image](https://user-images.githubusercontent.com/69512295/150953502-10dee46a-faa8-4b43-841f-8b099301b817.png)


related to #211 